### PR TITLE
Fixing large string issue

### DIFF
--- a/src/RedisClient/Connection/StreamConnection.php
+++ b/src/RedisClient/Connection/StreamConnection.php
@@ -87,7 +87,13 @@ class StreamConnection implements ConnectionInterface {
      * @return string
      */
     public function read($length) {
-        return fread($this->getResource(), $length);
+        $read = 0;
+        $data = '';
+        while ($read != $length) {
+            $data .= fread($this->getResource(), ($length - $read));
+            $read = strlen($data);
+        }
+        return $data;
     }
 
 }


### PR DESCRIPTION
`fread()` returns *up to* the `$length` specified. I was hitting an issue where large strings (eg, cached rendered pages ~20,000 bytes) would get truncated on reads in random spots, and successive reads would fail with unknown error codes. I tracked it down to this method. Since large data may not stream in time for `fread()` to pick it up all at once, the function was retuning partial data and the next read would get random gibberish from wherever the previous one had cut off.