### PR TITLE
info command returns array, not string

### DIFF
--- a/src/RedisClient/Command/Traits/Version2x6/ServerCommandsTrait.php
+++ b/src/RedisClient/Command/Traits/Version2x6/ServerCommandsTrait.php
@@ -218,7 +218,7 @@ trait ServerCommandsTrait {
      * @link http://redis.io/commands/info
      *
      * @param string $section
-     * @return string
+     * @return array
      */
     public function info($section = null) {
         return $this->returnCommand(['INFO'], null, $section ? [$section] : null, ResponseParser::PARSE_INFO);


### PR DESCRIPTION
Just a minor thing I noticed while debugging stuff.

I tried this with and without the section parameter. Both cases return an array and not a string.

Great job on this lib though. I just changed my app to this because nrk/predis seems to have stalled and does not support SCAN on clustered Redis, which I needed.