### PR TITLE
Bug fix: using XREAD command instead of XRANGE

### DIFF
--- a/src/RedisClient/Command/Traits/Version5x0/StreamsCommandsTrait.php
+++ b/src/RedisClient/Command/Traits/Version5x0/StreamsCommandsTrait.php
@@ -282,9 +282,10 @@ trait StreamsCommandsTrait {
         if (isset($block)) {
             $params[] = ['BLOCK', $block];
         }
+        $params[] = 'STREAMS';
         $params[] = $keys;
         $params[] = (array)$ids;
-        return $this->returnCommand(['XRANGE'], $keys, $params);
+        return $this->returnCommand(['XREAD'], $keys, $params);
     }
 
     /**


### PR DESCRIPTION
Currently, the xread method underneath uses the XRANGE command. According to the documentation (https://redis.io/commands/xread), XRANGE can behave like XREAD under certain conditions, but it provides different behavior, especially in the case of blocking stream reading.
After the bug fix, the behavior appears to be correct. Please correct me if I am wrong.