### PR TITLE
Resolves #81 - Add optional param values to linsert

### DIFF
--- a/src/RedisClient/Command/Traits/Version2x6/ListsCommandsTrait.php
+++ b/src/RedisClient/Command/Traits/Version2x6/ListsCommandsTrait.php
@@ -91,7 +91,7 @@ trait ListsCommandsTrait {
      * @return int The length of the list after the insert operation,
      * or -1 when the value pivot was not found. Or 0 when key was not found.
      */
-    public function linsert($key, $after = true, $pivot, $value) {
+    public function linsert($key, $after = true, $pivot = '', $value = '') {
         return $this->returnCommand(['LINSERT'], $key, [$key, $after ? 'AFTER' : 'BEFORE', $pivot, $value]);
     }
 


### PR DESCRIPTION
This is more just a quick fix to resolve issue #81. Really, $after should be at the end of the argument list (as $pivot and $value should always have arguments) or $after shouldn't have a default value, but both of those changes would break backward compatibility.